### PR TITLE
Protect against product image not existing

### DIFF
--- a/packages/composables/src/getters/productGetters.ts
+++ b/packages/composables/src/getters/productGetters.ts
@@ -40,7 +40,7 @@ export const getProductGallery = (product: ProductVariant): AgnosticMediaGallery
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const getProductCoverImage = product => product?._coverImage.src || '';
+export const getProductCoverImage = product => product?._coverImage?.src || '';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getProductFiltered = (products: ProductVariant[], filters: ProductVariantFilters | any = {}): ProductVariant[] => {


### PR DESCRIPTION
On line 43, one cannot assume that a _coverImage exists for a given product. Without the existence check before `.src`, an exception is thrown while testing products without images such as while putting a shop together.