### PR TITLE
Replaced custom client re-initialisation with context for customerQueries and customerMutation API

### DIFF
--- a/packages/api-client/src/api/changePassword/index.ts
+++ b/packages/api-client/src/api/changePassword/index.ts
@@ -13,7 +13,7 @@ export default async function changePassword(context, params) {
   };
 
   // Remove customer access token
-  return await context.CustomClient.graphQLClient.send(mutation, data).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(mutation(context), data).then(({model}) => {
     return model;
   });
 }

--- a/packages/api-client/src/api/customerMutations/buildMutations.ts
+++ b/packages/api-client/src/api/customerMutations/buildMutations.ts
@@ -1,15 +1,9 @@
 /* TODO: Fetch custom client directly, may be using context  */
-const Customclient = require('shopify-buy/index.unoptimized.umd.js');
-const CustomClient = Customclient.buildClient({
-  domain: 'YOUR SHOPIFY STORE DOMAIN',
-  storefrontAccessToken: 'YOUR STORE ACCESS TOKEN'
-});
+const changePasswordMutation: (context) => any = (context): any => {
+  const customerAccessToken = context.CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
+  const customer = context.CustomClient.graphQLClient.variable('customer', 'CustomerUpdateInput!');
 
-const changePasswordMutation: () => any = (): any => {
-  const customerAccessToken = CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
-  const customer = CustomClient.graphQLClient.variable('customer', 'CustomerUpdateInput!');
-
-  return CustomClient.graphQLClient.mutation('customerUpdate', [customerAccessToken, customer], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerUpdate', [customerAccessToken, customer], (root) => {
     root.add('customerUpdate', {args: {customerAccessToken, customer}}, (customer) => {
       customer.add('customer', (fields) => {
         fields.add('id');
@@ -32,11 +26,11 @@ const changePasswordMutation: () => any = (): any => {
   });
 };
 
-const forgotPasswordMutation: () => any = (): any => {
+const forgotPasswordMutation: (context) => any = (context): any => {
 
-  const email = CustomClient.graphQLClient.variable('email', 'String!');
+  const email = context.CustomClient.graphQLClient.variable('email', 'String!');
 
-  return CustomClient.graphQLClient.mutation('customerRecover', [email], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerRecover', [email], (root) => {
     root.add('customerRecover', {args: {email}}, (customer) => {
       customer.add('customerUserErrors', (error) => {
         error.add('code');
@@ -47,12 +41,11 @@ const forgotPasswordMutation: () => any = (): any => {
   });
 };
 
-const editProfileMutation: () => any = (): any => {
+const editProfileMutation: (context) => any = (context): any => {
+  const customerAccessToken = context.CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
+  const customer = context.CustomClient.graphQLClient.variable('customer', 'CustomerUpdateInput!');
 
-  const customerAccessToken = CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
-  const customer = CustomClient.graphQLClient.variable('customer', 'CustomerUpdateInput!');
-
-  return CustomClient.graphQLClient.mutation('customerUpdate', [customerAccessToken, customer], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerUpdate', [customerAccessToken, customer], (root) => {
     root.add('customerUpdate', {args: {customerAccessToken, customer}}, (customer) => {
       customer.add('customer', (fields) => {
         fields.add('id');
@@ -75,10 +68,10 @@ const editProfileMutation: () => any = (): any => {
   });
 };
 
-const signInMutation: () => any = (): any => {
-  const input = CustomClient.graphQLClient.variable('input', 'CustomerAccessTokenCreateInput!');
+const signInMutation: (context) => any = (context): any => {
+  const input = context.CustomClient.graphQLClient.variable('input', 'CustomerAccessTokenCreateInput!');
 
-  return CustomClient.graphQLClient.mutation('customerAccessTokenCreate', [input], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerAccessTokenCreate', [input], (root) => {
     root.add('customerAccessTokenCreate', {args: {input}}, (customer) => {
       customer.add('customerAccessToken', (token) => {
         token.add('accessToken');
@@ -93,11 +86,11 @@ const signInMutation: () => any = (): any => {
   });
 };
 
-const signOutMutation: () => any = (): any => {
+const signOutMutation: (context) => any = (context): any => {
 
-  const customerAccessToken = CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
+  const customerAccessToken = context.CustomClient.graphQLClient.variable('customerAccessToken', 'String!');
 
-  return CustomClient.graphQLClient.mutation('customerAccessTokenDelete', [customerAccessToken], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerAccessTokenDelete', [customerAccessToken], (root) => {
     root.add('customerAccessTokenDelete', {args: {customerAccessToken}}, (customer) => {
       customer.add('deletedAccessToken');
       customer.add('deletedCustomerAccessTokenId');
@@ -109,11 +102,11 @@ const signOutMutation: () => any = (): any => {
   });
 };
 
-const signUpMutation: () => any = (): any => {
+const signUpMutation: (context) => any = (context): any => {
 
-  const input = CustomClient.graphQLClient.variable('input', 'CustomerCreateInput!');
+  const input = context.CustomClient.graphQLClient.variable('input', 'CustomerCreateInput!');
 
-  return CustomClient.graphQLClient.mutation('customerCreate', [input], (root) => {
+  return context.CustomClient.graphQLClient.mutation('customerCreate', [input], (root) => {
     root.add('customerCreate', {args: {input}}, (customer) => {
       customer.add('customer', (token) => {
         token.add('id');

--- a/packages/api-client/src/api/customerMutations/buildQueries.ts
+++ b/packages/api-client/src/api/customerMutations/buildQueries.ts
@@ -1,14 +1,7 @@
 /* eslint-disable func-names */
-/* TODO: Fetch custom client directly, may be using context  */
-const Customclient = require('shopify-buy/index.unoptimized.umd.js');
-const CustomClient = Customclient.buildClient({
-  domain: 'YOUR SHOPIFY STORE DOMAIN',
-  storefrontAccessToken: 'YOUR STORE ACCESS TOKEN'
-});
+const customerQuery: (token: string, context) => any = (token, context): any => {
 
-const customerQuery: (token: string) => any = (token): any => {
-
-  return CustomClient.graphQLClient.query((root) => {
+  return context.CustomClient.graphQLClient.query((root) => {
     root.add('customer', {
       args: {
         customerAccessToken: token
@@ -27,9 +20,9 @@ const customerQuery: (token: string) => any = (token): any => {
   });
 };
 
-const ordersQuery: (pages: number, token: string) => any = (pages, token): any => {
+const ordersQuery: (pages: number, token: string, context) => any = (pages, token, context): any => {
 
-  return CustomClient.graphQLClient.query((root) => {
+  return context.CustomClient.graphQLClient.query((root) => {
     root.add('customer', {
       args: {
         customerAccessToken: token
@@ -76,9 +69,9 @@ const ordersQuery: (pages: number, token: string) => any = (pages, token): any =
   });
 };
 
-const addressesQuery: (pages: number, token: string) => any = (pages, token): any => {
+const addressesQuery: (pages: number, token: string, context) => any = (pages, token, context): any => {
 
-  return CustomClient.graphQLClient.query((root) => {
+  return context.CustomClient.graphQLClient.query((root) => {
     root.add('customer', {
       args: {
         customerAccessToken: token

--- a/packages/api-client/src/api/editProfile/index.ts
+++ b/packages/api-client/src/api/editProfile/index.ts
@@ -10,7 +10,7 @@ export default async function editProfile(context, params) {
     customer: profile
   };
   // send user data to authenticate, return token if valid
-  return await context.CustomClient.graphQLClient.send(mutation, data).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(mutation(context), data).then(({model}) => {
     return model;
   });
 }

--- a/packages/api-client/src/api/fetchAddresses/index.ts
+++ b/packages/api-client/src/api/fetchAddresses/index.ts
@@ -6,7 +6,7 @@ import { addressesQuery as query } from './../customerMutations/buildQueries';
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function fetchAddresses(context, params, customQuery?: CustomQuery) {
 // send user data to authenticate, return token if valid
-  const addresses = await context.CustomClient.graphQLClient.send(query(10, params)).then(({model}) => {
+  const addresses = await context.CustomClient.graphQLClient.send(query(10, params, context)).then(({model}) => {
     if (model) {
       return model.customer;
     }

--- a/packages/api-client/src/api/fetchCustomer/index.ts
+++ b/packages/api-client/src/api/fetchCustomer/index.ts
@@ -6,7 +6,7 @@ import { customerQuery as query } from './../customerMutations/buildQueries';
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function fetchCustomer(context, params, customQuery?: CustomQuery) {
   // send user data to authenticate, return token if valid
-  return await context.CustomClient.graphQLClient.send(query(params)).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(query(params, context)).then(({model}) => {
     return model;
   });
 }

--- a/packages/api-client/src/api/fetchOrders/index.ts
+++ b/packages/api-client/src/api/fetchOrders/index.ts
@@ -6,7 +6,7 @@ import { ordersQuery as query } from './../customerMutations/buildQueries';
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function fetchOrders(context, params, customQuery?: CustomQuery) {
 // send user data to authenticate, return token if valid
-  const orders = await context.CustomClient.graphQLClient.send(query(10, params)).then(({model}) => {
+  const orders = await context.CustomClient.graphQLClient.send(query(10, params, context)).then(({model}) => {
     return model;
   });
 

--- a/packages/api-client/src/api/signIn/index.ts
+++ b/packages/api-client/src/api/signIn/index.ts
@@ -13,7 +13,7 @@ export default async function signIn(context, params, customQuery?: CustomQuery)
     }
   };
   // send user data to authenticate, return token if valid
-  return await context.CustomClient.graphQLClient.send(mutation, data).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(mutation(context), data).then(({model}) => {
     return model;
   });
 }

--- a/packages/api-client/src/api/signOut/index.ts
+++ b/packages/api-client/src/api/signOut/index.ts
@@ -9,7 +9,7 @@ export default async function signOut(context, params) {
   };
 
   // Remove customer access token
-  return await context.CustomClient.graphQLClient.send(mutation, data).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(mutation(context), data).then(({model}) => {
     return model;
   });
 }

--- a/packages/api-client/src/api/signUp/index.ts
+++ b/packages/api-client/src/api/signUp/index.ts
@@ -10,7 +10,7 @@ export default async function signUp(context, params, customQuery?: CustomQuery)
   };
 
   // send userdata to register
-  return await context.CustomClient.graphQLClient.send(mutation, data).then(({model}) => {
+  return await context.CustomClient.graphQLClient.send(mutation(context), data).then(({model}) => {
     return model;
   });
 }


### PR DESCRIPTION
Passed context as a parameter and accessed it to the API level and replaced custom client re-initialization with context for customer queries and customerMutation API