### PR TITLE
Fix theme/tsconfig.json

### DIFF
--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -27,5 +27,5 @@
       "@nuxt/types",
       "nuxt-i18n"
     ]
-  },
+  }
 }


### PR DESCRIPTION
Hi there,

I ran into a error message when deploying to my `Vercel` project.

It reads `Error: Can not read tsconfig.json from /vercel/path0` .

<img width="709" alt="vercel_tsconfig_json_error" src="https://user-images.githubusercontent.com/1394049/117107929-69c6ea00-adbd-11eb-9269-8fc1e321312d.png">

I found that the `tsconfig.json` automatically generated by `$ npx @vue-storefront/cli init` violates the json format.

And I fixed it, then the error has been resolved.

------

So I pushed a commit https://github.com/vuestorefront/shopify/commit/8964badd8a7a9418c7126b567c13856b2770a837 , maybe it helps someone.

Thank you for reading.

