### PR TITLE
fix: added a sample terms & conditions page

### DIFF
--- a/packages/theme/components/LoginModal.vue
+++ b/packages/theme/components/LoginModal.vue
@@ -231,13 +231,15 @@
                   class="form__element"
                 >
                 <template #label>
-                  <SfButton
-                  class='sf-button--pure'
+                  <SfLink
+                  class='sf-button--pure terms-link'
                   type = 'button'
-                  @click="handleTermsLink"
+                  :link="localePath({name: 'TermsAndConditions'})"
+                  @click.native="toggleLoginModal()"
                 >
-                    &nbsp;&nbsp;Accept Terms &amp; Conditions
-                  </SfButton></template>
+                    Accept Terms &amp; Conditions
+                  </SfLink>
+                  </template>
                 </SfCheckbox>
               </ValidationProvider>
             </div>
@@ -310,11 +312,6 @@ export default {
     const form = ref({});
     const createAccount = ref(false);
     const rememberMe = ref(false);
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    const handleTermsLink = () => {
-      toggleLoginModal();
-      $router.push('/terms-and-conditions');
-    };
     const { register, login, loading, user } = useUser();
     const { send: sendNotification} = useUiNotification();
     watch(isLoginModalOpen, () => {
@@ -387,7 +384,6 @@ export default {
       toggleLoginModal,
       handleLogin,
       handleRegister,
-      handleTermsLink,
       sendNotification,
       isForgotPassword,
       handleForgotPassword
@@ -501,5 +497,8 @@ export default {
       max-width: 280px;
     }
   }
+}
+.terms-link {
+  margin-left: var(--spacer-xs);
 }
 </style>

--- a/packages/theme/pages/TermsAndConditions.vue
+++ b/packages/theme/pages/TermsAndConditions.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    Terms &amp; Conditions
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+
+export default defineComponent({
+  name: 'TermsAndConditions',
+  setup() {
+    
+  },
+})
+</script>
+
+<style lang="scss">
+
+</style>


### PR DESCRIPTION
Fix for #85 missing terms & condition page

## Description
We added a terms & condition page and refactor the implementation of SfLink

## Related Issue
#85 


## How Has This Been Tested?
It's run locally and manually tested

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/15663986/141072436-e4757a98-659a-4f7a-aedf-db62313912c3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
