### PR TITLE
fix: nuxtjs composition peerDep

### DIFF
--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -17,7 +17,7 @@
     "@types/js-cookie": "^2.2.6"
   },
   "peerDependencies": {
-    "@nuxtjs/composition-api": "1.2.4"
+    "@nuxtjs/composition-api": "0.29.3"
   },
   "files": [
     "lib/**/*",


### PR DESCRIPTION
This is to address #92 incorrect peer dependency version for @nuxtjs/composition-api