### PR TITLE
Resolves: https://github.com/vuestorefront/shopify/issues/94

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -13,11 +13,12 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
+    "@nuxtjs/composition-api": "^0.30.0",
+    "@types/js-cookie": "^2.2.6",
     "@vue-storefront/core": "~2.5.0",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
-    "shopify-buy": "^2.11.0",
-    "@types/js-cookie": "^2.2.6"
+    "shopify-buy": "^2.11.0"
   },
   "devDependencies": {
     "@types/shopify-buy": "^2.10.5",


### PR DESCRIPTION
## Description
Adding @nuxtjs/composition-api as a dependency to api-client, given it is no longer provided as a dependency in vue-storefront/core. That package only references it as a peerDependency, whereas the package used to include @vue/composition-api as a bundled dependency

## Related Issue
https://github.com/vuestorefront/shopify/issues/94

## Motivation and Context
Resolve compilation issue that resulted from adoption of vue-storefront 2.5.0 which transitioned to use of @nuxtjs/composition-api 

## How Has This Been Tested?

- Validated compilation and app start up locally
- Checked / validated browser console for any errors / warnings, and there were none

## Screenshots (if appropriate):
![Screen Shot 2021-11-17 at 1 44 09 PM](https://user-images.githubusercontent.com/21325640/142262837-085d04c5-8217-4294-b717-2ecf88b5260a.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
