### PR TITLE
Upgraded core-js dependency Feature/103

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -13,11 +13,12 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
+    "@nuxtjs/composition-api": "^0.30.0",
+    "@types/js-cookie": "^2.2.6",
     "@vue-storefront/core": "~2.5.0",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
-    "shopify-buy": "^2.11.0",
-    "@types/js-cookie": "^2.2.6"
+    "shopify-buy": "^2.11.0"
   },
   "devDependencies": {
     "@types/shopify-buy": "^2.10.5",

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -167,7 +167,7 @@ const config = {
     ]
   },
   build: {
-    transpile: ['vee-validate/dist/rules'],
+    transpile: ['vee-validate/dist/rules', 'storefront-ui'],
     plugins: [
       new webpack.DefinePlugin({
         'process.VERSION': JSON.stringify({

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,6 +17,8 @@
     "@vue-storefront/nuxt": "~2.5.0",
     "@vue-storefront/nuxt-theme": "~2.5.0",
     "@vue-storefront/shopify": "1.0.6",
+    "@vue-storefront/shopify-api": "1.0.6",
+    "axios": "^0.24.0",
     "cookie-universal-nuxt": "^2.1.3",
     "core-js": "^2.6.5",
     "isomorphic-fetch": "^2.2.1",
@@ -28,6 +30,7 @@
   "devDependencies": {
     "@nuxt/types": "^2.13.3",
     "@nuxt/typescript-build": "^2.0.0",
+    "@vue-storefront/core": "^2.5.0",
     "@vue/test-utils": "^1.0.0-beta.27",
     "babel-jest": "^24.1.0",
     "ejs": "^3.0.2",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,7 +20,7 @@
     "@vue-storefront/shopify-api": "1.0.6",
     "axios": "^0.24.0",
     "cookie-universal-nuxt": "^2.1.3",
-    "core-js": "^2.6.5",
+    "core-js": "^3.19.1",
     "isomorphic-fetch": "^2.2.1",
     "nuxt": "^2.13.3",
     "nuxt-i18n": "^6.5.0",


### PR DESCRIPTION

## Description
Upgraded core-js dependency in packages/theme to remediate build warning of deprecated dependency and to allow for the package to benefit from the incremental features of the core-js 3.x version

## Related Issue
https://github.com/vuestorefront/shopify/issues/103

## Motivation and Context
Change is beneficial to reduce unnecessary warnings and to introduce incremental features via the core-js dependency

## How Has This Been Tested?

- Validated build warning was removed 
- Validated app compiled and started with no incremental warnings or browser console errors

## Screenshots (if appropriate):

![Screen Shot 2021-11-17 at 1 44 09 PM](https://user-images.githubusercontent.com/21325640/142267142-de5425fb-eb02-4fd7-9041-4b7af10674de.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
