### PR TITLE
feat: added shopify api for getting product data with context country

### DIFF
--- a/packages/apollo/src/api/getProductV2.ts
+++ b/packages/apollo/src/api/getProductV2.ts
@@ -1,0 +1,78 @@
+import { CustomQuery } from '@vue-storefront/core'
+import { gql } from '@apollo/client/core'
+import { ShopifyApolloContext } from '../library'
+import { QueryRoot, QueryRootProductsArgs } from '../shopify'
+
+export const DEFAULT_QUERY = `
+query GET_PRODUCT($handle: String, $country: CountryCode) @inContext(country: $country) {
+    product(handle: $handle) {
+      images(first: 1) {
+        edges {
+          node {
+            src
+            originalSrc
+            id
+            height
+            width
+            altText
+          }
+        }
+      }
+      variants(first: 1) {
+        edges {
+          node {
+            price
+            priceV2 {
+              amount
+              currencyCode
+            }
+            availableForSale
+            compareAtPrice
+          }
+        }
+      }
+      options {
+        id
+        name
+        values
+      }
+      tags
+      productType
+      title
+      vendor
+      publishedAt
+      createdAt
+      updatedAt
+      publishedAt
+      id
+      description
+      descriptionHtml
+      handle
+    }
+  }
+  
+`
+
+export default async function getProductV2(context: ShopifyApolloContext, params: Record<string, string | number>, customQuery?: CustomQuery) {
+  const variables = {
+    ...params,
+    country: context.config.country
+  }
+
+  const { product } = context.extendQuery(
+    customQuery,
+    {
+      product: {
+        query: DEFAULT_QUERY,
+        variables
+      }
+    }
+  )
+
+  const response = await context.client.apolloClient.query<QueryRoot, QueryRootProductsArgs>({
+    query: gql(product.query) as any,
+    variables: product.variables
+  })
+
+  return response ?? null
+}

--- a/packages/apollo/src/api/index.ts
+++ b/packages/apollo/src/api/index.ts
@@ -3,13 +3,16 @@ import customerRecover from './customerRecover'
 import customerCreate from './customerCreate'
 import availableFilters from './availableFilters';
 import getCollection from './getCollection';
+import getProductV2 from './getProductV2';
+
 
 const apis = {
   searchProduct,
   customerRecover,
   customerCreate,
   availableFilters,
-  getCollection
+  getCollection,
+  getProductV2
 }
 
 export type ShopifyApolloAPIs = {

--- a/packages/composables/src/index.ts
+++ b/packages/composables/src/index.ts
@@ -15,11 +15,12 @@ import useWishlist from './useWishlist';
 import useCart from './useCart';
 import useForgotPassword from './useForgotPassword';
 import useAvailableFilters from './useAvailableFilters';
-
+import useProductV2 from './useProductV2';
 
 export {
   useAvailableFilters,
   useCart,
+  useProductV2,
   useCategory,
   useCheckout,
   useForgotPassword,

--- a/packages/composables/src/useProductV2/index.ts
+++ b/packages/composables/src/useProductV2/index.ts
@@ -1,0 +1,16 @@
+import {
+    Context,
+    useProductFactory,
+    ProductsSearchParams,
+    UseProductFactoryParams
+  } from '@vue-storefront/core';
+  import { ProductsResponse } from '../types';
+  
+  const params: UseProductFactoryParams<ProductsResponse, any> = {
+    productsSearch: (context: Context, params: ProductsSearchParams): Promise<ProductsResponse> => {
+      return context.$shopify.api.getProductV2(params);
+    }
+  };
+  
+  export default useProductFactory<ProductsResponse, any>(params);
+  


### PR DESCRIPTION
We've added a way to fetch locale or translations from your Shopify admin setup and configuration country in our middleware.config.js

## Description
This will add way for developers to setup internationalization base on the country given in the middleware.config.js 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
