### PR TITLE
fix: category page loading error

### DIFF
--- a/packages/composables/src/useCart/index.ts
+++ b/packages/composables/src/useCart/index.ts
@@ -108,7 +108,7 @@ const params: UseCartFactoryParams<Cart, CartItem, Product | Product[]> = {
           const buff = Buffer.from(variationIDPlain);
           variantId = buff.toString('base64');
         }
-        return currentCart.lineItems.find((item) => item.variant.id === variantId);
+        return currentCart?.lineItems?.find((item) => item.variant.id === variantId);
       }
       return false;
     };


### PR DESCRIPTION
Category page could not load due to an `undefined` error in the composable `useCart`'s function `isInCart`

## Description
Added optional chaining to each property when returning existence of an item in the cart.

## Related Issue
https://github.com/vuestorefront/shopify/issues/171

## Motivation and Context
Loading any category page would result in an error due to the `cart`'s property `lineItems` being `undefined`.

See error message below:

```js
client.js?06a0:103 TypeError: Cannot read properties of undefined (reading 'find')
    at getBasketItemByProduct (index.ts?8298:96:1)
    at isInCart (index.ts?8298:101:1)
    at Object.eval [as isInCart] (commonMethods.ts?5fd5:6:1)
    at VueComponent.isInCart (useCartFactory.ts?8d08:163:1)
    at eval (Category.vue?aa55:186:1)
    at Proxy.renderList (vue.common.dev.js?4650:2649:1)
    at Proxy.render (Category.vue?aa55:156:1)
    at eval (vue-composition-api.esm.js?a6f4:1911:1)
    at activateCurrentInstance (vue-composition-api.esm.js?a6f4:1861:1)
    at Proxy.$options.render (vue-composition-api.esm.js?a6f4:1910:1)
```

## How Has This Been Tested?
- Ran all tests across every package.
- Built and used the package in local VSF installation.
- Loaded multiple category pages and all were successfully loaded.

__Testing Environment__
- Windows 11
- Node v14.18.0
- Google Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
