### PR TITLE
fix: nuxt project does not build when "strict: true" is used

### DIFF
--- a/packages/apollo/src/api/getCollection.ts
+++ b/packages/apollo/src/api/getCollection.ts
@@ -68,8 +68,12 @@ type GetCollectionQueryArgs = QueryRootCollectionArgs & ProductFilter
 
 const PRICE_FILTER_RANGE = ['min', 'max']
 
-function convertFacetFiltersLocalToShopify(filters: Record<string, any>): ProductFilter {
+function convertFacetFiltersLocalToShopify(filters?: Record<string, any>): ProductFilter {
     const result: ProductFilter = {}
+
+    if (!filters) {
+      return result;
+    }
 
     for (const key of Object.keys(filters)) {
         // This condition will set the price range filter


### PR DESCRIPTION
Fix: Nuxt project does not build when "strict: true" is used.

This is due to an argument type issue in the function `convertFacetFiltersLocalToShopify`.

## Description
Added optional type `?` with early return if `filters` is undefined.

## Related Issue
https://github.com/vuestorefront/shopify/issues/221

## Motivation and Context

For strict-type checking projects that want to use TypeScript in its full power `"strict": true`, a type error was being thrown for the above function.

## How Has This Been Tested?
Re-ran nuxt project with the above change and type check passes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
