### PR TITLE
fix(product): product info tabs move below overlay

### DIFF
--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -615,6 +615,7 @@ export default {
   &__tabs {
     margin: var(--spacer-lg) auto var(--spacer-2xl);
     --tabs-title-font-size: var(--font-size--lg);
+    --tabs-title-z-index: 0;
     @include for-desktop {
       margin-top: var(--spacer-2xl);
     }


### PR DESCRIPTION
Closes #269 

## Description
This will fix the overlay styling issue on the search modal vs the content that should be behind.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
