### PR TITLE
fix: not using deprecated set output

### DIFF
--- a/.github/workflows/docs-deployment.yaml
+++ b/.github/workflows/docs-deployment.yaml
@@ -18,7 +18,7 @@ jobs:
           path: version.txt
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - name: Build and publish docker image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -40,7 +40,7 @@ jobs:
           name: version
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - uses: chrnorm/deployment-action@releases/v1
         name: Create GitHub deployment
         id: deployment


### PR DESCRIPTION
## Description 
It fixes the usage of the deprecated --set-output command. Now, we are using a modern up-to-date approach.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 